### PR TITLE
Some restart tests and notes

### DIFF
--- a/dymos/load_case.py
+++ b/dymos/load_case.py
@@ -63,6 +63,10 @@ def load_case(problem, case):
     case : Case object or OpenMDAO Problem instance
         A Case from a CaseRecorder file.
     """
+
+    #  TODO: use list_inputs and list_outputs with prom_name=True to avoid some of the compexity
+    #  of figuring out promoted_names manually here
+
     inputs = case.inputs if case.inputs is not None else None
     outputs = case.outputs if case.outputs is not None else None
     vars = dict(inputs)
@@ -117,6 +121,7 @@ def load_case(problem, case):
             problem[f'{phase_path}.controls:{control_name}'] = \
                 phase.interpolate(t_all, control_all, nodes='control_input')
 
+        #  TODO: Polynomial controls values should not be interpolated.
         for control_name, options in phase.polynomial_control_options.items():
             control_all = outputs[f'{phase_path}.timeseries.polynomial_controls:{control_name}']
             problem[f'{phase_path}.polynomial_controls:{control_name}'] = \

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -7,10 +7,28 @@ import os
 
 
 def run_problem(problem, refine=False, refine_iteration_limit=10, restart=None):
+    """
+    Run a dymos-specific OpenMDAO problem with some extra capabilities.
+
+    Parameters
+    ----------
+    problem
+    refine
+    refine_iteration_limit
+    restart
+
+    Returns
+    -------
+
+    """
     if restart:  # restore variables from database file specified by 'restart'
         cr = om.CaseReader(restart)
-        case = cr.get_case(-1)  # BUG: use last case, ideally it should be the only one, but there are many
+        case = cr.get_case(-1)
         print('overwriting problem variables from restart file:', restart)
+
+        # TODO: use the load case functionality here
+        # TODO: because it has the same name as an openmdao function but is dymos specific,
+        # TODO: we should probably rename it to restart(case) or load_restart(case).
 
         # change metadata from restart file
         phases = {phase_path: problem.model._get_subsystem(phase_path)
@@ -30,10 +48,10 @@ def run_problem(problem, refine=False, refine_iteration_limit=10, restart=None):
 
         problem._initial_condition_cache = {}
 
-    # record variables to database when running driver
+    # TODO: Ultimately this recorder should be attached to problem and then recorded manually
+    # TODO: Until POEM_011 is implemented, use a driver recorder.
     problem.driver.add_recorder(om.SqliteRecorder('dymos_solution.db'))
-    problem.driver.recording_options['includes'] = ['*timeseries*']
-    problem.record_iteration('final')    # BUG: not working to save only last iteration?
+    problem.driver.recording_options['includes'] = ['*']
     problem.run_driver()
 
     if refine:

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -84,11 +84,11 @@ class TestRunProblem(unittest.TestCase):
         # first run a problem to generate a 'dymos_solution.db' restart file
         tf = 100
         p1 = hs_problem_radau(tf)
-        dm.run_problem(p1, True, refine_iteration_limit=2)
+        dm.run_problem(p1, refine=True, refine_iteration_limit=2)
 
         # create a new problem restarting from the last
         p2 = hs_problem_radau(tf)
-        dm.run_problem(p2, True, refine_iteration_limit=4, restart='dymos_solution.db')
+        dm.run_problem(p2, refine=True, refine_iteration_limit=4, restart='dymos_solution.db')
 
     def test_run_HS_problem_gl(self):
         p = om.Problem(model=om.Group())

--- a/dymos/utils/command_line.py
+++ b/dymos/utils/command_line.py
@@ -1,0 +1,26 @@
+#from __future__ import print_function
+
+#import openmdao.api as om
+import dymos as dm
+#import numpy as np
+import argparse
+
+
+def dymos_cmd():
+    parser = argparse.ArgumentParser(description='Dymos Command Line Tool')
+    parser.add_argument('script', type=str,
+                        help='Python script that creates a Dymos problem to run')
+    parser.add_argument('-r', '--restart', default=None,
+                        help='Provide a database file to continue from a previous run (default: None)')
+    parser.add_argument('-g', '--grid', action='store_true',
+                        help='Enable grid refinement')
+    parser.add_argument('-l', '--limit', default=10,
+                        help='Grid refinement iteration limit (default: 10)')
+    args = parser.parse_args()
+
+    print('args', args)
+    # TODO: how to convert script name to problem object?
+    #dm.run_problem(probemObject, refine=args['grid'], refine_iteration_limit=args['limit'], restart=args['restart'])
+
+if __name__ == '__main__':
+    dymos_cmd()

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,7 @@ setup(name='dymos',
         'redbaron'
     ],
     zip_safe=False,
+    entry_points={
+      'console_scripts': ['dymos=dymos.utils.command_line:dymos_cmd'],
+    }
 )


### PR DESCRIPTION
Added some todo notes and a few tests for the restart capability.
The brachistochrone test fails with some derivative errors, so it may be necessary to contact the OpenMDAO team about them.
First order of business, though, is using load_case to repopulate the problem from the case data.

The "manual" recording capability is achieved by attaching a recorder to the problem, not the driver.  However, there are some problems with the way this is implemented in OpenMDAO right now, and a new POEM has been created to address it. (https://github.com/OpenMDAO/POEMs/pull/22)  When those changes are implemented, we can turn the restart recorder into a one attached to the problem.