### PR TITLE
Vanderpol

### DIFF
--- a/dymos/examples/vanderpol/vanderpol_dymos.py
+++ b/dymos/examples/vanderpol/vanderpol_dymos.py
@@ -78,6 +78,10 @@ def vanderpol(transcription='gauss-lobatto', num_segments=8, transcription_order
     # setup the problem
     p.setup(check=True)
 
+    # TODO - Dymos API will soon provide a way to specify this.
+    for phase in traj._phases.values():
+        phase.linear_solver = om.LinearRunOnce()
+
     p['traj.phase0.t_initial'] = 0.0
     p['traj.phase0.t_duration'] = t_final
 


### PR DESCRIPTION
### Summary

I got the vanderpol distributed test to pass with the following changes:

1. Got rid of vanderpol_rate_connect component. It turns out that you don't need to manually gather these into a single vector.  Anything can connects to or use a distributed variable and openmdao handles any MPI communication necessary.  (Note, our docs are not clear about this and need some improvement)

2. DirectSolver is unsupported in any group above a distributed component, so I put in some code to change it to LinearRunOnce after setup.  This will change when the dymos API has a feature that allows the user to specify it. (Note: OpenMDAO should have raised an error. This bug has been reported.)

3. Added missing derivatives. 

4. There was an additional bug in OpenMDAO. I am still working on a test for it, but you can pull down my `bug1` branch of OpenMDAO to get it now.

### Related Issues

- Resolves #

### Status

- [ x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
